### PR TITLE
cmake: add libipt_static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ option(PTSEG  "Enable ptseg, a PSB segment finder")
 option(PTUNIT "Enable ptunit, a unit test system and libipt unit tests")
 option(MAN "Enable man pages (requires pandoc)." OFF)
 option(SIDEBAND "Enable libipt-sb, a sideband correlation library")
+option(BUILD_SHARED_LIBS "Build the shared library" ON)
 
 if (SIDEBAND)
   option(PEVENT "Enable perf_event sideband support." OFF)

--- a/libipt/CMakeLists.txt
+++ b/libipt/CMakeLists.txt
@@ -83,7 +83,7 @@ endif (CMAKE_HOST_WIN32)
 
 set(LIBIPT_FILES ${LIBIPT_FILES} ${LIBIPT_SECTION_FILES})
 
-add_library(libipt SHARED
+add_library(libipt
   ${LIBIPT_FILES}
 )
 

--- a/sideband/CMakeLists.txt
+++ b/sideband/CMakeLists.txt
@@ -43,7 +43,7 @@ if (CMAKE_HOST_WIN32)
   )
 endif (CMAKE_HOST_WIN32)
 
-add_library(libipt-sb SHARED ${LIBSB_FILES})
+add_library(libipt-sb ${LIBSB_FILES})
 
 # put the version into the header
 #


### PR DESCRIPTION
Linux distributions like Fedora and OpenSUSE build gdb against a static
libipt, which is obtained by patching libipt/CMakeLists.txt:
...
-add_library(libipt SHARED
+add_library(libipt STATIC
...

Add libipt_static, a static library version of libipt to
libipt/CMakeLists.txt that can be used instead.

Signed-off-by: Tom de Vries <tdevries@suse.de>