### PR TITLE
test: Change it type to avoid implicit signedness conversion

### DIFF
--- a/libipt/test/src/ptunit-image_section_cache.c
+++ b/libipt/test/src/ptunit-image_section_cache.c
@@ -1594,7 +1594,7 @@ static int worker_add(void *arg)
 		uint64_t laddr;
 		int sec;
 
-		laddr = 0x1000ull * (it % 23);
+		laddr = 0x1000ull * ((uint64_t)it % 23);
 
 		for (sec = 0; sec < num_sections; ++sec) {
 			struct pt_section *section;


### PR DESCRIPTION
Otherwise, clang with -Wsign-conversion complains about the assignment
to laddr here, because it is signed:

test/src/ptunit-image_section_cache.c:1597:27: error: implicit conversion changes signedness: 'int' to 'unsigned long long' [-Werror,-Wsign-conversion]
                laddr = 0x1000ull * (it % 23);
                                  ~  ~~~^~~~