### PR TITLE
Time to tsc

### DIFF
--- a/pevent/src/pevent.c
+++ b/pevent/src/pevent.c
@@ -43,6 +43,15 @@ int pev_time_to_tsc(uint64_t *tsc, uint64_t time,
 	if (!tsc || !config)
 		return -pte_internal;
 
+	/* "time 0" is for synthesized events, and is not a real time. Using
+	 * the normal conversion for a synthesized time causes problems, so
+	 * just translate it as TSC time 0 ("beginning of time").
+	 */
+	if (!time) {
+		*tsc = 0;
+		return 0;
+	}
+
 	if (!pev_config_has(config, time_zero))
 		return -pte_bad_config;
 

--- a/pevent/test/src/ptunit-pevent.c
+++ b/pevent/test/src/ptunit-pevent.c
@@ -287,13 +287,13 @@ static struct ptunit_result time_to_tsc_bad_config(void)
 	memset(&config, 0, sizeof(config));
 	config.time_mult = 1;
 
-	errcode = pev_time_to_tsc(&tsc, 0x0ull, &config);
+	errcode = pev_time_to_tsc(&tsc, 0x1ull, &config);
 	ptu_int_eq(errcode, -pte_bad_config);
 
 	config.size = sizeof(config);
 	config.time_mult = 0;
 
-	errcode = pev_time_to_tsc(&tsc, 0x0ull, &config);
+	errcode = pev_time_to_tsc(&tsc, 0x1ull, &config);
 	ptu_int_eq(errcode, -pte_bad_config);
 
 	return ptu_passed();


### PR DESCRIPTION
The quick description:

Synthesized events (like an initial exec and mmaps) are recorded with time 0, even though this isn't a real time. If this is treated like an actual time, in some situations the conversion to TSC makes it wrap around to seem like a very LATE event and so isn't seen when libipt (e.g., seen via ptxed) syncs events to apply them in order. Details on when this happens are below, but the quick answer is that "time 0" should always be converted to TSC value 0, and not use the conversion formula. This ensures that synthesized events are all "beginning of time" events and are processed correctly.

---------------

The details:

Converting a system time to a TSC value involves two values: "Time Multiplier" which scales ticks in the system's base frequency to seconds, and "Time Zero" which reflects the amount of time between when the TSC was started (at zero) and when the system time was started (at zero). In most cases, the "Time Zero" will be a small negative value, reflecting the time for the system to initialize -- BIOS startup, grub loading, etc. For example, on the system I'm on right now, time zero is -9,809,827,620 reflecting the 9.8 seconds it took the system to initialize. Converting a system time to TSC then subtracts this from the system time, so actually adds 9.8 seconds to get the elapsed system time since TSC was zero.

When an event is recorded with time 0, it's obviously not being recorded at the time the system started, and this is a synthesized time. In the scenario just described, time 0 has 9.8 seconds added and then is turned into a number of ticks of the TSC with the multiplier. This then is an approximation of the value of the TSC when the system time was set to zero, and will be a small-ish positive value that comes before any real measured time. This is fine for most analysis tasks.

However, on one of my laptops, putting it to sleep and waking it up (which I do often) resets the TSC to zero. In this case, "Time Zero" changes from being a small negative value to being a large positive value reflecting the real time from system boot to the most recent wake-up. So TSC time zero changes from being a time *before* the system time was zero to being a time *after* the system time was zero. If the conversion is made for time zero in this case, instead of a small negative value being subtracted (so a small value being added) to the system time, a much larger positive value is subtracted. In most cases, this results in a negative value for "time since TSC zero" and so as an unsigned 64-bit value the converted TSC is a very LARGE value, and so things like the original MMAPs for the program and the loader are mistakenly taken as late events are are not processed by the decoder. Without those events being processed, I was seeing this when running ptxed:

```
[1a0, 7f5dc67e0100: error: no memory mapped at this address]
```

Here's a specific example of times and constants from such a run:

At program start, system time is 13063238792466 and TSC is 0x000009edf2a95bb1 = 10917583084465
  mul = 1016801932
  shift = 31
  tzero = 7893923727649

So converting system time to TSC is (shown in a python shell):

```
>>> ((13063238792466-7893923727649)%2**64)*2**31 // 1016801932
10917583084465
```

Converting time zero to TSC is

```
>>> ((0-7893923727649)%2**64)*2**31 // 1016801932
38959469940365971994
```

So what should be a very early event is in fact very late - far after the program runs, so it's never seen.

That's a very long description for what is really a simple bug and bug fix, but I went through all of that so I though I'd share!

