### PR TITLE
Don't check for PTHREAD_MUTEX_NORMAL macro

### DIFF
--- a/include/posix/threads.h
+++ b/include/posix/threads.h
@@ -38,10 +38,6 @@
 
 #include <pthread.h>
 
-#ifndef PTHREAD_MUTEX_NORMAL
-#  define PTHREAD_MUTEX_NORMAL PTHREAD_MUTEX_TIMED_NP
-#endif
-
 #include <stdint.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
On FreeBSD, PTHREAD_MUTEX_NORMAL is just an enum value, not a macro, so it will fail this check, and PTHREAD_MUTEX_NORMAL will be redefined to PTHREAD_MUTEX_TIMED_NP, which does not exist on FreeBSD.

Additionally, PTHREAD_MUTEX_NORMAL is required to exist by POSIX, so this fallback probably isn't doing much.

Signed-off-by: Alyssa Ross <hi@alyssa.is>