### PR TITLE
Ss18/enhancement0

### DIFF
--- a/doc/howto_build.md
+++ b/doc/howto_build.md
@@ -47,7 +47,7 @@ components, or optional build variants.
 By default, only the decoder library is built.  Other components can be enabled
 by setting the respective cmake variable to ON.
 
-The following optional components are availble:
+The following optional components are available:
 
     PTUNIT             A simple unit test framework.
                        A collection of unit tests for libipt.
@@ -92,8 +92,8 @@ available on all supported platforms.
 
     GCOV                Support for code coverage using libgcov.
 
-                        This build variant requires libgcov and is not availble
-                        on Windows.
+                        This build variant requires libgcov and is not 
+                        available on Windows.
 
 
     DEVBUILD            Enable compiler warnings and turn them into errors.

--- a/libipt/include/intel-pt.h.in
+++ b/libipt/include/intel-pt.h.in
@@ -1451,7 +1451,8 @@ struct pt_event {
 
 		/** Event: tick. */
 		struct {
-			/** The instruction address near which the tick occured.
+			/** The instruction address near which the tick
+			 *  occurred.
 			 *
 			 * A timestamp can sometimes be attributed directly to
 			 * an instruction (e.g. to an indirect branch that

--- a/libipt/internal/include/pt_image.h
+++ b/libipt/internal/include/pt_image.h
@@ -80,8 +80,8 @@ extern void pt_image_fini(struct pt_image *image);
  *
  * Add @section identified by @isid to @image at @vaddr in @asid.  If @section
  * overlaps with existing sections, the existing sections are shrunk, split, or
- * removed to accomodate @section.  Absence of a section identifier is indicated
- * by an @isid of zero.
+ * removed to accommodate @section.  Absence of a section identifier is
+ * indicated by an @isid of zero.
  *
  * Returns zero on success.
  * Returns -pte_internal if @image, @section, or @asid is NULL.

--- a/pttc/src/yasm.c
+++ b/pttc/src/yasm.c
@@ -617,7 +617,7 @@ int pd_parse(struct pt_directive *pd, struct state *st)
 		goto cleanup;
 	}
 
-	/* make "multiple" strings by artifically terminating them with
+	/* make "multiple" strings by artificially terminating them with
 	 * '\0' then get directive and payload substrings, which will
 	 * have leading and trailing whitespace "removed".
 	 */


### PR DESCRIPTION
Fixed typos:

accomodate -> accommodate
artifically -> artificially
availble -> available
occured -> occurred

Found with: https://github.com/ss18/grep-typos