### PR TITLE
Fix various spelling mistakes in comments and text found by codespell

### DIFF
--- a/doc/howto_capture.md
+++ b/doc/howto_capture.md
@@ -342,7 +342,7 @@ When decoding system-wide trace, we need to correlate context switch sideband
 events with decoded instructions from the trace to find a suitable location for
 switching the traced memory image for the scheduled-in process.  The heuristics
 we use rely on sufficiently precise timing information.  If timing information
-is too coarse, we might map the contex switch to the wrong location.
+is too coarse, we might map the context switch to the wrong location.
 
 When tracing ring-0, we use any code in kernel space.  Since the kernel is
 mapped into every process, this is good enough as long as we are not interested

--- a/doc/man/pt_blk_sync_forward.3.md
+++ b/doc/man/pt_blk_sync_forward.3.md
@@ -55,7 +55,7 @@ pointed to by *decoder* onto the trace stream in *decoder*'s trace buffer.
 They search for a Packet Stream Boundary (PSB) packet in the trace stream and,
 if successful, set *decoder*'s current position and synchronization position to
 that packet and start processing packets.  For synchronization to be
-successfull, there must be a full PSB+ header in the trace stream.
+successful, there must be a full PSB+ header in the trace stream.
 
 **pt_blk_sync_forward**() searches in forward direction from *decoder*'s
 current position towards the end of the trace buffer.  If *decoder* has been

--- a/doc/man/pt_config.3.md
+++ b/doc/man/pt_config.3.md
@@ -211,7 +211,7 @@ errata
     The *pt_errata* structure is a collection of one-bit-fields, one for each
     supported erratum.  Duplicate errata are indicated by comments for the
     erratum for which the workaround was first implemented.  Set the field of an
-    erratum to enable the correspondig workaround.
+    erratum to enable the corresponding workaround.
 
     The *pt_errata* structure is declared as:
 

--- a/doc/man/pt_insn_sync_forward.3.md
+++ b/doc/man/pt_insn_sync_forward.3.md
@@ -56,7 +56,7 @@ buffer.
 They search for a Packet Stream Boundary (PSB) packet in the trace stream and,
 if successful, set *decoder*'s current position and synchronization position to
 that packet and start processing packets.  For synchronization to be
-successfull, there must be a full PSB+ header in the trace stream.
+successful, there must be a full PSB+ header in the trace stream.
 
 **pt_insn_sync_forward**() searches in forward direction from *decoder*'s
 current position towards the end of the trace buffer.  If *decoder* has been

--- a/doc/man/pt_qry_sync_forward.3.md
+++ b/doc/man/pt_qry_sync_forward.3.md
@@ -57,7 +57,7 @@ pointed to by *decoder* onto the trace stream in *decoder*'s trace buffer.
 They search for a Packet Stream Boundary (PSB) packet in the trace stream and,
 if successful, set *decoder*'s current position and synchronization position to
 that packet and start processing packets.  For synchronization to be
-successfull, there must be a full PSB+ header in the trace stream.
+successful, there must be a full PSB+ header in the trace stream.
 
 If the *ip* argument is not NULL, these functions provide the code memory
 address at which tracing starts in the variable pointed to by *ip*.  If tracing

--- a/libipt/include/intel-pt.h.in
+++ b/libipt/include/intel-pt.h.in
@@ -315,7 +315,7 @@ struct pt_errata {
 	 *
 	 * Certain Intel PT (Processor Trace) packets including FUPs (Flow
 	 * Update Packets), should be issued only between TIP.PGE (Target IP
-	 * Packet - Packet Generaton Enable) and TIP.PGD (Target IP Packet -
+	 * Packet - Packet Generation Enable) and TIP.PGD (Target IP Packet -
 	 * Packet Generation Disable) packets.  When outside a TIP.PGE/TIP.PGD
 	 * pair, as a result of IA32_RTIT_STATUS.FilterEn[0] (MSR 571H) being
 	 * cleared, an OVF (Overflow) packet may be unexpectedly followed by a

--- a/libipt/src/pt_block_decoder.c
+++ b/libipt/src/pt_block_decoder.c
@@ -332,7 +332,7 @@ static int pt_blk_start(struct pt_block_decoder *decoder)
 	if (!decoder)
 		return -pte_internal;
 
-	/* We need to process satus update events from PSB+ in order to
+	/* We need to process status update events from PSB+ in order to
 	 * initialize our internal state and be able to diagnose
 	 * inconsistencies during tracing.
 	 *
@@ -2173,7 +2173,7 @@ pt_blk_proceed_no_event_fill_cache(struct pt_block_decoder *decoder,
 	 *     entries that point to this decision point will have non-zero
 	 *     displacement.
 	 *
-	 *     We could proceed after a near direct call but we migh as well
+	 *     We could proceed after a near direct call but we might as well
 	 *     postpone it to the next iteration.  Make sure to end the block if
 	 *     @decoder->flags.variant.block.end_on_call is set, though.
 	 *
@@ -2434,7 +2434,7 @@ static int pt_blk_proceed_no_event_cached(struct pt_block_decoder *decoder,
 							  bcache, msec,
 							  bcache_fill_steps);
 
-	/* If we switched sections, the origianl section must have been split
+	/* If we switched sections, the original section must have been split
 	 * underneath us.  A split preserves the block cache of the original
 	 * section.
 	 *

--- a/libipt/src/pt_encoder.c
+++ b/libipt/src/pt_encoder.c
@@ -192,7 +192,7 @@ static int pt_ipc_size(enum pt_ip_compression ipc)
 
 /* Encode an integer value.
  *
- * Writes the \@size least signifficant bytes of \@value starting from \@pos.
+ * Writes the \@size least significant bytes of \@value starting from \@pos.
  *
  * The caller needs to ensure that there is enough space available.
  *

--- a/libipt/src/pt_event_decoder.c
+++ b/libipt/src/pt_event_decoder.c
@@ -1093,7 +1093,7 @@ static int pt_evt_decode_exstop(struct pt_event_decoder *decoder,
 			 *
 			 * Let's enqueue MWAIT; we'll enqueue EXSTOP below, as
 			 * well, unless we have further events pending.  In
-			 * that case, enqueing EXSTOP will have to wait.
+			 * that case, enqueuing EXSTOP will have to wait.
 			 */
 			if (packet->ip) {
 				struct pt_event *mwait;
@@ -2213,7 +2213,7 @@ static int pt_evt_handle_skd010(struct pt_event_decoder *decoder)
 		case ppt_tnt_8:
 		case ppt_tnt_64:
 			/* This is a clear indication that the erratum
-			 * apllies.
+			 * applies.
 			 *
 			 * Yet, we can't recover from it as we wouldn't know how
 			 * many TNT bits will have been used when we eventually

--- a/libipt/src/pt_query_decoder.c
+++ b/libipt/src/pt_query_decoder.c
@@ -213,7 +213,7 @@ static int pt_qry_start(struct pt_query_decoder *decoder, uint64_t *ip)
 	if (!decoder)
 		return -pte_invalid;
 
-	/* We need to process satus update events from PSB+ in order to
+	/* We need to process status update events from PSB+ in order to
 	 * provide the start IP.
 	 *
 	 * On the other hand, we need to provide those same status events to

--- a/pttc/include/file.h
+++ b/pttc/include/file.h
@@ -104,7 +104,7 @@ struct file_list {
 
 /* Allocates a new file list.
  *
- * Returns a non-NULL file list object on succes; NULL otherwise.
+ * Returns a non-NULL file list object on success; NULL otherwise.
  */
 extern struct file_list *fl_alloc(void);
 

--- a/pttc/include/parse.h
+++ b/pttc/include/parse.h
@@ -145,7 +145,7 @@ extern int parse(const char *pttfile, const struct pt_config *conf);
 
 /* Parses an empty payload.
  *
- * Returns 0 on success; a negative enum errcode othewise.
+ * Returns 0 on success; a negative enum errcode otherwise.
  * Returns -err_parse_trailing_tokens if @payload has non whitespace
  * characters.
  */

--- a/pttc/include/util.h
+++ b/pttc/include/util.h
@@ -43,7 +43,7 @@
  */
 extern int duplicate_name(char **d, const char *s, size_t n);
 
-/* Converts the string @str into an usigned x-bit value @val using base @base.
+/* Converts the string @str into an unsigned x-bit value @val using base @base.
  *
  * Returns 0 on success; a negative enum errcode otherwise.
  * Returns -err_internal if either @str or @val is NULL.

--- a/pttc/src/parse.c
+++ b/pttc/src/parse.c
@@ -429,7 +429,7 @@ static int p_gen_expfile(struct parser *p)
 				zero_padding = 1;
 				line += 1;
 			}
-			/* chek if ? padding is requested.  */
+			/* check if ? padding is requested.  */
 			else if (*line == '?') {
 				qmark_padding = 1;
 				zero_padding = 1;
@@ -437,7 +437,7 @@ static int p_gen_expfile(struct parser *p)
 				line += 1;
 			}
 
-			/* advance i to the first non alpha-numeric
+			/* advance i to the first non alphanumeric
 			 * character. all characters everything from
 			 * line[0] to line[i-1] belongs to the label
 			 * name.

--- a/ptunit/include/ptunit.h
+++ b/ptunit/include/ptunit.h
@@ -345,7 +345,7 @@ extern int ptunit_report(const struct ptunit_suite *suite);
 	} while (0)
 
 
-/* Run a single unit test with fixture and an explict argument list.
+/* Run a single unit test with fixture and an explicit argument list.
  *
  * The first argument in the argument list is typically the fixture.
  */

--- a/sideband/src/pt_sb_pevent.c
+++ b/sideband/src/pt_sb_pevent.c
@@ -1194,7 +1194,7 @@ static int pt_sb_pevent_map(struct pt_sb_session *session,
 	if (errcode < 0)
 		return errcode;
 
-	/* The optional system root directoy. */
+	/* The optional system root directory. */
 	sysroot = priv->sysroot;
 
 	/* Some filenames do not represent actual files on disk.  We handle

--- a/test/src/apl12-psb.ptt
+++ b/test/src/apl12-psb.ptt
@@ -29,7 +29,7 @@
 ;
 ;        Certain Intel PT (Processor Trace) packets including FUPs (Flow
 ;        Update Packets), should be issued only between TIP.PGE (Target IP
-;        Packet - Packet Generaton Enable) and TIP.PGD (Target IP Packet -
+;        Packet - Packet Generation Enable) and TIP.PGD (Target IP Packet -
 ;        Packet Generation Disable) packets.  When outside a TIP.PGE/TIP.PGD
 ;        pair, as a result of IA32_RTIT_STATUS.FilterEn[0] (MSR 571H) being
 ;        cleared, an OVF (Overflow) packet may be unexpectedly followed by a

--- a/test/src/apl12-tip_pge.ptt
+++ b/test/src/apl12-tip_pge.ptt
@@ -29,7 +29,7 @@
 ;
 ;        Certain Intel PT (Processor Trace) packets including FUPs (Flow
 ;        Update Packets), should be issued only between TIP.PGE (Target IP
-;        Packet - Packet Generaton Enable) and TIP.PGD (Target IP Packet -
+;        Packet - Packet Generation Enable) and TIP.PGD (Target IP Packet -
 ;        Packet Generation Disable) packets.  When outside a TIP.PGE/TIP.PGD
 ;        pair, as a result of IA32_RTIT_STATUS.FilterEn[0] (MSR 571H) being
 ;        cleared, an OVF (Overflow) packet may be unexpectedly followed by a

--- a/test/src/ptdump-no-offset.ptt
+++ b/test/src/ptdump-no-offset.ptt
@@ -27,7 +27,7 @@
 
 ; Test that ptdump honors --no-offset
 ;
-; Variant: the packet is printed inthe first column.
+; Variant: the packet is printed in the first column.
 ;
 ; opt:ptdump --no-offset
 


### PR DESCRIPTION
There are some spelling mistakes found using codespell. Fix these.