### PR TITLE
libipt: Fix typo in intel-pt.h.in

### DIFF
--- a/libipt/include/intel-pt.h.in
+++ b/libipt/include/intel-pt.h.in
@@ -323,7 +323,7 @@ struct pt_errata {
 	 */
 	uint32_t apl12:1;
 
-	/** APL11: Intel(R) PT OVF Pakcet May Be Followed by TIP.PGD Packet
+	/** APL11: Intel(R) PT OVF Packet May Be Followed by TIP.PGD Packet
 	 *
 	 * If Intel PT (Processor Trace) encounters an internal buffer overflow
 	 * and generates an OVF (Overflow) packet just as IA32_RTIT_CTL (MSR

--- a/test/src/apl11.ptt
+++ b/test/src/apl11.ptt
@@ -25,7 +25,7 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ; POSSIBILITY OF SUCH DAMAGE.
 
-; APL11: Intel(R) PT OVF Pakcet May Be Followed by TIP.PGD Packet
+; APL11: Intel(R) PT OVF Packet May Be Followed by TIP.PGD Packet
 ;
 ;        If Intel PT (Processor Trace) encounters an internal buffer overflow
 ;        and generates an OVF (Overflow) packet just as IA32_RTIT_CTL (MSR


### PR DESCRIPTION
There are some spelling mistakes, so I fixed them.