### PR TITLE
Look up Intel XED header under namespace

### DIFF
--- a/ptxed/src/ptxed.c
+++ b/ptxed/src/ptxed.c
@@ -46,7 +46,7 @@
 #include <inttypes.h>
 #include <errno.h>
 
-#include <xed-interface.h>
+#include <xed/xed-interface.h>
 
 
 /* The type of decoder to be used. */


### PR DESCRIPTION
Intel XED's public headers has been under `$PREFIX/include/xed/` for at least a couple of years now.